### PR TITLE
Give build docker container workflow package write permissions

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+  
     steps:
       - name: Get Release Tag
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Looks like the default permissions have been reduced for security purposes.

Adding package write permissions to allow container to be uploaded to the container registry