### PR TITLE
Allow tuning of build parallelisation

### DIFF
--- a/.github/workflows/test_released_action.yml
+++ b/.github/workflows/test_released_action.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
         
-      - name: GTest Action
+      - name: GTest Action without exisiting CMake file
         uses: apollo-fire/gtest-action@v0.0.5
         with:
           test-path: 'test/working_unittest_project'
@@ -28,3 +28,9 @@ jobs:
           test-path: 
             "test/working_unittest_project;\
             test/working_unittest_project_with_existing_cmake"
+
+      - name: GTest Action building with j8 flag set
+        uses: apollo-fire/gtest-action@v0.0.5
+        with:
+          test-path: 'test/working_unittest_project'
+          parallel-compilation-count: 8

--- a/.github/workflows/test_released_action.yml
+++ b/.github/workflows/test_released_action.yml
@@ -13,24 +13,24 @@ jobs:
         uses: actions/checkout@v4.1.1
         
       - name: GTest Action without exisiting CMake file
-        uses: apollo-fire/gtest-action@feature/tune-parallel-compilation
+        uses: apollo-fire/gtest-action@v0.0.6
         with:
           test-path: 'test/working_unittest_project'
 
       - name: GTest Action with existing CMake file
-        uses: apollo-fire/gtest-action@feature/tune-parallel-compilation
+        uses: apollo-fire/gtest-action@v0.0.6
         with:
           test-path: 'test/working_unittest_project_with_existing_cmake'
 
       - name: GTest Action with mix of project styles, with and without existing CMake file
-        uses: apollo-fire/gtest-action@feature/tune-parallel-compilation
+        uses: apollo-fire/gtest-action@v0.0.6
         with:
           test-path: 
             "test/working_unittest_project;\
             test/working_unittest_project_with_existing_cmake"
 
       - name: GTest Action building with j8 flag set
-        uses: apollo-fire/gtest-action@feature/tune-parallel-compilation
+        uses: apollo-fire/gtest-action@v0.0.6
         with:
           test-path: 'test/working_unittest_project'
           parallel-compilation-count: 8

--- a/.github/workflows/test_released_action.yml
+++ b/.github/workflows/test_released_action.yml
@@ -13,24 +13,24 @@ jobs:
         uses: actions/checkout@v4.1.1
         
       - name: GTest Action without exisiting CMake file
-        uses: apollo-fire/gtest-action@v0.0.5
+        uses: apollo-fire/gtest-action@feature/tune-parallel-compilation
         with:
           test-path: 'test/working_unittest_project'
 
       - name: GTest Action with existing CMake file
-        uses: apollo-fire/gtest-action@v0.0.5
+        uses: apollo-fire/gtest-action@feature/tune-parallel-compilation
         with:
           test-path: 'test/working_unittest_project_with_existing_cmake'
 
       - name: GTest Action with mix of project styles, with and without existing CMake file
-        uses: apollo-fire/gtest-action@v0.0.5
+        uses: apollo-fire/gtest-action@feature/tune-parallel-compilation
         with:
           test-path: 
             "test/working_unittest_project;\
             test/working_unittest_project_with_existing_cmake"
 
       - name: GTest Action building with j8 flag set
-        uses: apollo-fire/gtest-action@v0.0.5
+        uses: apollo-fire/gtest-action@vfeature/tune-parallel-compilation
         with:
           test-path: 'test/working_unittest_project'
           parallel-compilation-count: 8

--- a/.github/workflows/test_released_action.yml
+++ b/.github/workflows/test_released_action.yml
@@ -30,7 +30,7 @@ jobs:
             test/working_unittest_project_with_existing_cmake"
 
       - name: GTest Action building with j8 flag set
-        uses: apollo-fire/gtest-action@vfeature/tune-parallel-compilation
+        uses: apollo-fire/gtest-action@feature/tune-parallel-compilation
         with:
           test-path: 'test/working_unittest_project'
           parallel-compilation-count: 8

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Docker Action that can build and execute Googletest cases
 ## Example usage
 ### Where source code is included in test directories
 ```yaml
-- uses: apollo-fire/gtest-action@v0.0.5
+- uses: apollo-fire/gtest-action@v0.0.6
   with:
     test-path: 'src/tests/drivers;src/tests/application'
 ```
 ### Where source code is separate to test directory
 ```yaml
-- uses: apollo-fire/gtest-action@v0.0.5
+- uses: apollo-fire/gtest-action@v0.0.6
   with:
     test-path: 'tests/'
     source-path: 'src/'
 ```
 ### Where build parallelisation is overridden
 ```yaml
-- uses: apollo-fire/gtest-action@v0.0.5
+- uses: apollo-fire/gtest-action@v0.0.6
   with:
     test-path: 'src/tests/drivers;src/tests/application'
     parallel-compilation-count: 4

--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ Docker Action that can build and execute Googletest cases
     test-path: 'tests/'
     source-path: 'src/'
 ```
+### Where build parallelisation is overridden
+```yaml
+- uses: apollo-fire/gtest-action@v0.0.5
+  with:
+    test-path: 'src/tests/drivers;src/tests/application'
+    parallel-compilation-count: 4
+```

--- a/action.yml
+++ b/action.yml
@@ -10,12 +10,17 @@ inputs:
   source-path:
     description: 'relative path to directory containing source code, if different to test path'
     required: false
+  parallel-compilation-count:
+    description: 'j flag value to pass to make when building unit tests'
+    required: true
+    default: '2'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/apollo-fire/gtest-action:v0.0.5'
   args:
     - ${{ inputs.test-path }}
     - ${{ inputs.source-path }}
+    - ${{ inputs.parallel-compilation-count }}
 branding:
   icon: 'code'
   colour: 'orange'

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: 'unset'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/apollo-fire/gtest-action:v0.0.5'
+  image: 'docker://ghcr.io/apollo-fire/gtest-action:v0.0.6-pre1'
   args:
     - ${{ inputs.test-path }}
     - ${{ inputs.source-path }}

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: 'unset'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/apollo-fire/gtest-action:v0.0.6-pre1'
+  image: 'docker://ghcr.io/apollo-fire/gtest-action:v0.0.6'
   args:
     - ${{ inputs.test-path }}
     - ${{ inputs.source-path }}

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   parallel-compilation-count:
     description: 'j flag value to pass to make when building unit tests'
     required: true
-    default: '2'
+    default: 'unset'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/apollo-fire/gtest-action:v0.0.5'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,19 +2,28 @@
 
 # Args
 # $1 paths to the unit test projects, delimited by ;
+# $2 relative path to project under test's sourcecode
+# $3 value to use for makes' j flag
 
-# Determine processor count
-CPU_COUNT=$(nproc)
-echo "Initialising CPU_COUNT to $CPU_COUNT"
-
-if ! [ "$CPU_COUNT" -eq "$CPU_COUNT" ] 2> /dev/null;
+# Check if user has passed in an integer value
+if ! [ "$3" -eq "$3" ] 2> /dev/null;
 then
-    echo "CPU_COUNT is not an integer"
-    CPU_COUNT=1
+    # Automatically determine processor count
+    CPU_COUNT=$(nproc)
+    if ! [ "$CPU_COUNT" -eq "$CPU_COUNT" ] 2> /dev/null;
+    then
+        echo "CPU_COUNT is not an integer"
+        CPU_COUNT=1
+    else
+        CPU_COUNT=$((CPU_COUNT - 1))
+    fi    
 else
-    CPU_COUNT=$((CPU_COUNT - 1))
+    # Use value passed in by user
+    CPU_COUNT=$(($3 < CPU_COUNT ? $3 : CPU_COUNT))
 fi
 echo "Setting CPU_COUNT to $CPU_COUNT"
+
+
 
 # Split the delimited string into an array of paths
 IFS=';' read -ra paths <<< "$1"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,9 @@
 # Check if user has passed in an integer value
 if ! [ "$3" -eq "$3" ] 2> /dev/null;
 then
-    # Automatically determine processor count
+    # Automatically determine processing unit count
     CPU_COUNT=$(nproc)
+    echo "Detected $CPU_COUNT processing units"
     if ! [ "$CPU_COUNT" -eq "$CPU_COUNT" ] 2> /dev/null;
     then
         echo "CPU_COUNT is not an integer"
@@ -18,8 +19,9 @@ then
         CPU_COUNT=$((CPU_COUNT - 1))
     fi    
 else
+    echo "Requested $3 processing units"
     MAX_CPU=8
-    # Use value passed in by user
+    # Use value passed in by user, throttled to MAX_CPU
     CPU_COUNT=$(($3 < MAX_CPU ? $3 : MAX_CPU))
 fi
 echo "Setting CPU_COUNT to $CPU_COUNT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,8 +18,9 @@ then
         CPU_COUNT=$((CPU_COUNT - 1))
     fi    
 else
+    MAX_CPU=8
     # Use value passed in by user
-    CPU_COUNT=$(($3 < CPU_COUNT ? $3 : CPU_COUNT))
+    CPU_COUNT=$(($3 < MAX_CPU ? $3 : MAX_CPU))
 fi
 echo "Setting CPU_COUNT to $CPU_COUNT"
 


### PR DESCRIPTION
Added ```parallel-compilation-count``` input to the action to allow builds to utilise up to 8 processing units.

When the option is not specified the action defaults to trying to use (processing units - 1)