### PR TITLE
Remove user command from Docker Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk --no-cache add build-base=0.5-r3 \
                        bash=5.1.16-r2 \
                        valgrind=3.19.0-r0
 RUN mkdir /workdir
+RUN groupadd -r gtest && \
+    useradd -r -g gtest gtest
 
 COPY entrypoint.sh /entrypoint.sh
 COPY CMakeLists.txt /CMakeLists.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apk --no-cache add build-base=0.5-r3 \
                        bash=5.1.16-r2 \
                        valgrind=3.19.0-r0
 RUN mkdir /workdir
-RUN groupadd -r gtest && \
-    useradd -r -g gtest gtest
+RUN addgroup -r gtest && \
+    adduser -r -g gtest gtest
 
 COPY entrypoint.sh /entrypoint.sh
 COPY CMakeLists.txt /CMakeLists.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN apk --no-cache add build-base=0.5-r3 \
                        bash=5.1.16-r2 \
                        valgrind=3.19.0-r0
 RUN mkdir /workdir
-RUN addgroup -r gtest && \
-    adduser -r -g gtest gtest
 
 COPY entrypoint.sh /entrypoint.sh
 COPY CMakeLists.txt /CMakeLists.txt
@@ -19,4 +17,5 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 HEALTHCHECK CMD exit 0
 
-USER gtest
+# Use alpine's guest user
+USER guest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+#checkov:skip=CKV_DOCKER_3: "Ensure that a user for the container has been created"
+#GitHub actions require that the docker image use the root user
+#https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
+
 FROM alpine:3.16.2
 
 RUN apk --no-cache add build-base=0.5-r3 \
@@ -16,6 +20,3 @@ COPY CMakeLists.txt /CMakeLists.txt
 ENTRYPOINT ["/entrypoint.sh"]
 
 HEALTHCHECK CMD exit 0
-
-# Use alpine's guest user
-USER guest

--- a/README.md
+++ b/README.md
@@ -4,27 +4,27 @@ Docker Action that can build and execute Googletest cases
 ## Example usage
 ### Where source code is included in test directories
 ```yaml
-- uses: apollo-fire/gtest-action@v0.0.8
+- uses: apollo-fire/gtest-action@v0.0.9
   with:
     test-path: 'src/tests/drivers;src/tests/application'
 ```
 ### Where source code is separate to test directory
 ```yaml
-- uses: apollo-fire/gtest-action@v0.0.8
+- uses: apollo-fire/gtest-action@v0.0.9
   with:
     test-path: 'tests/'
     source-path: 'src/'
 ```
 ### Where build parallelisation is overridden
 ```yaml
-- uses: apollo-fire/gtest-action@v0.0.8
+- uses: apollo-fire/gtest-action@v0.0.9
   with:
     test-path: 'src/tests/drivers;src/tests/application'
     parallel-compilation-count: 4
 ```
 ### Where tests should be run in a shuffled order 10 times
 ```yaml
-- uses: apollo-fire/gtest-action@v0.0.8
+- uses: apollo-fire/gtest-action@v0.0.9
   with:
     test-path: 'src/tests/drivers;src/tests/application'
     parallel-compilation-count: 4

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: 'docker'
   # image: Dockerfile
-  image: 'docker://ghcr.io/apollo-fire/gtest-action:v0.0.8'
+  image: 'docker://ghcr.io/apollo-fire/gtest-action:v0.0.9'
   args:
     - ${{ inputs.test-path }}
     - ${{ inputs.source-path }}


### PR DESCRIPTION
GitHub Docker Actions are required to use the root user, see: https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user

Bump version numbers ready for a formal v0.0.9 release to replace the broken v0.0.8 one