### PR TITLE
Added triggers to do dry run when PR raised

### DIFF
--- a/.github/workflows/build_docker_image_dry_run.yml
+++ b/.github/workflows/build_docker_image_dry_run.yml
@@ -4,6 +4,12 @@ name: Dry run Docker Container Build
 on:
   workflow_dispatch:
 
+  pull_request_target:
+    branches: ['dependabot/**']
+
+  pull_request:
+    types: [opened, synchronize, edited]
+    
 permissions: read-all
 
 jobs:


### PR DESCRIPTION
To reduce the likelihood of proposed changes preventing docker containers from building carry out a dry run (docker image built but not uploaded).